### PR TITLE
fix: provide spirv-builder with a path to a specific target-spec file

### DIFF
--- a/crates/cargo-gpu/src/lib.rs
+++ b/crates/cargo-gpu/src/lib.rs
@@ -43,6 +43,9 @@ pub mod spirv_builder_cli {
         /// Shader target.
         pub shader_target: String,
 
+        /// Path to target spec file.
+        pub path_to_target_spec: std::path::PathBuf,
+
         /// Set cargo default-features.
         pub no_default_features: bool,
 

--- a/crates/cargo-gpu/src/main.rs
+++ b/crates/cargo-gpu/src/main.rs
@@ -65,6 +65,69 @@ const SPIRV_BUILDER_FILES: &[(&str, &str)] = &[
 
 const SPIRV_STD_TOOLCHAIN_PAIRS: &[(&str, &str)] = &[("0.10", "nightly-2024-04-24")];
 
+const TARGET_SPECS: &[(&str, &str)] = &[
+    (
+        "spirv-unknown-opengl4.0.json",
+        include_str!("../target-specs/spirv-unknown-opengl4.0.json"),
+    ),
+    (
+        "spirv-unknown-opengl4.1.json",
+        include_str!("../target-specs/spirv-unknown-opengl4.1.json"),
+    ),
+    (
+        "spirv-unknown-opengl4.2.json",
+        include_str!("../target-specs/spirv-unknown-opengl4.2.json"),
+    ),
+    (
+        "spirv-unknown-opengl4.3.json",
+        include_str!("../target-specs/spirv-unknown-opengl4.3.json"),
+    ),
+    (
+        "spirv-unknown-opengl4.5.json",
+        include_str!("../target-specs/spirv-unknown-opengl4.5.json"),
+    ),
+    (
+        "spirv-unknown-spv1.0.json",
+        include_str!("../target-specs/spirv-unknown-spv1.0.json"),
+    ),
+    (
+        "spirv-unknown-spv1.1.json",
+        include_str!("../target-specs/spirv-unknown-spv1.1.json"),
+    ),
+    (
+        "spirv-unknown-spv1.2.json",
+        include_str!("../target-specs/spirv-unknown-spv1.2.json"),
+    ),
+    (
+        "spirv-unknown-spv1.3.json",
+        include_str!("../target-specs/spirv-unknown-spv1.3.json"),
+    ),
+    (
+        "spirv-unknown-spv1.4.json",
+        include_str!("../target-specs/spirv-unknown-spv1.4.json"),
+    ),
+    (
+        "spirv-unknown-spv1.5.json",
+        include_str!("../target-specs/spirv-unknown-spv1.5.json"),
+    ),
+    (
+        "spirv-unknown-vulkan1.0.json",
+        include_str!("../target-specs/spirv-unknown-vulkan1.0.json"),
+    ),
+    (
+        "spirv-unknown-vulkan1.1.json",
+        include_str!("../target-specs/spirv-unknown-vulkan1.1.json"),
+    ),
+    (
+        "spirv-unknown-vulkan1.1spv1.4.json",
+        include_str!("../target-specs/spirv-unknown-vulkan1.1spv1.4.json"),
+    ),
+    (
+        "spirv-unknown-vulkan1.2.json",
+        include_str!("../target-specs/spirv-unknown-vulkan1.2.json"),
+    ),
+];
+
 /// Cargo dependency for `spirv-builder` and the rust toolchain channel.
 #[derive(Debug, Clone)]
 struct Spirv {
@@ -229,6 +292,16 @@ impl Install {
         }
     }
 
+    fn write_target_spec_files(&self) {
+        let cli = self.spirv_cli();
+        let checkout = cli.cached_checkout_path();
+        for (filename, contents) in TARGET_SPECS.iter() {
+            let path = checkout.join(filename);
+            let mut file = std::fs::File::create(&path).unwrap();
+            file.write_all(contents.as_bytes()).unwrap();
+        }
+    }
+
     // Install the binary pair and return the paths, (dylib, cli).
     fn run(&self) -> (std::path::PathBuf, std::path::PathBuf) {
         // Ensure the cache dir exists
@@ -271,6 +344,7 @@ impl Install {
                 checkout.display()
             );
             self.write_source_files();
+            self.write_target_spec_files();
 
             log::debug!("building artifacts");
             let output = std::process::Command::new("cargo")
@@ -357,6 +431,11 @@ impl Build {
             dylib_path,
             shader_crate: self.shader_crate.clone(),
             shader_target: self.shader_target.clone(),
+            path_to_target_spec: self
+                .install
+                .spirv_cli()
+                .cached_checkout_path()
+                .join(format!("{}.json", self.shader_target)),
             no_default_features: self.no_default_features,
             features: self.features.clone(),
             output_dir: self.output_dir.clone(),

--- a/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.0.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.0.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "opengl4.0",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-opengl4.0",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.1.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.1.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "opengl4.1",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-opengl4.1",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.2.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.2.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "opengl4.2",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-opengl4.2",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.3.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.3.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "opengl4.3",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-opengl4.3",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.5.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-opengl4.5.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "opengl4.5",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-opengl4.5",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-spv1.0.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-spv1.0.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "spv1.0",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-spv1.0",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-spv1.1.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-spv1.1.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "spv1.1",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-spv1.1",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-spv1.2.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-spv1.2.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "spv1.2",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-spv1.2",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-spv1.3.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-spv1.3.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "spv1.3",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-spv1.3",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-spv1.4.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-spv1.4.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "spv1.4",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-spv1.4",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-spv1.5.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-spv1.5.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "spv1.5",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-spv1.5",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.0.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.0.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "vulkan1.0",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-vulkan1.0",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.1.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.1.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "vulkan1.1",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-vulkan1.1",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.1spv1.4.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.1spv1.4.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "vulkan1.1spv1.4",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-vulkan1.1spv1.4",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.2.json
+++ b/crates/cargo-gpu/target-specs/spirv-unknown-vulkan1.2.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "vulkan1.2",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-vulkan1.2",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/spirv-builder-cli/src/main.rs
+++ b/crates/spirv-builder-cli/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
         dylib_path,
         shader_crate,
         shader_target,
+        path_to_target_spec,
         no_default_features,
         features,
         output_dir,
@@ -36,6 +37,7 @@ fn main() {
     } = {
         let mut builder = SpirvBuilder::new(shader_crate, &shader_target)
             .rustc_codegen_spirv_location(dylib_path)
+            .target_spec(path_to_target_spec)
             .print_metadata(MetadataPrintout::None)
             .multimodule(true);
 


### PR DESCRIPTION
This copies the "target specification" files into the cache directory, and passes a path to one of them to `spirv-builder`. Fixes #10