### PR TITLE
fix: standardize linkage paths with forward slashes

### DIFF
--- a/crates/spirv-builder-cli/src/lib.rs
+++ b/crates/spirv-builder-cli/src/lib.rs
@@ -3,7 +3,7 @@
 /// Shader source and entry point that can be used to create shader linkage.
 #[derive(serde::Serialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Linkage {
-    pub source_path: std::path::PathBuf,
+    pub source_path: String,
     pub entry_point: String,
     pub wgsl_entry_point: String,
 }
@@ -11,7 +11,13 @@ pub struct Linkage {
 impl Linkage {
     pub fn new(entry_point: impl AsRef<str>, source_path: impl AsRef<std::path::Path>) -> Self {
         Self {
-            source_path: source_path.as_ref().to_path_buf(),
+            // Force a forward slash convention here so it works on all OSs
+            source_path: source_path
+                .as_ref()
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/"),
             wgsl_entry_point: entry_point.as_ref().replace("::", ""),
             entry_point: entry_point.as_ref().to_string(),
         }


### PR DESCRIPTION
These changes make the `source_path` in `spirv_builder_cli::Linkage` a `String` that is ensured to have forward slashes for path components. 

This should keep the manifest from showing a git diff after building shaders on Windows when those shaders have not changed. 

This should also keep downstream libraries from showing a git diff if they happen to use the manifest.json file for compile-time code generation.