### PR TITLE
Panic-less code and user prompt for toolchain installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +88,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 name = "cargo-gpu"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "directories",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossterm",
  "directories",
  "env_logger 0.10.2",
  "http",
@@ -165,6 +166,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +256,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fnv"
@@ -339,6 +375,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +410,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -397,6 +461,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -482,10 +578,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "rustix"
+version = "0.38.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -536,6 +651,42 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "spirv-builder-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ resolver = "2"
 anyhow = "1.0.94"
 clap = { version = "4.4.8", features = ["derive"] }
 chrono = { version = "0.4.38", default-features = false, features = ["std"] }
+crossterm = "0.28.1"
 directories = "5.0.1"
 env_home = "0.1.0"
 env_logger = "0.10"
@@ -49,7 +50,6 @@ multiple_crate_versions = { level = "allow", priority = 1 }
 pub_with_shorthand = { level = "allow", priority = 1 }
 partial_pub_fields = { level = "allow", priority = 1 }
 pattern_type_mismatch = { level = "allow", priority = 1 }
-print_stdout = { level = "allow", priority = 1 }
 std_instead_of_alloc = { level = "allow", priority = 1 }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
+anyhow = "1.0.94"
 clap = { version = "4.4.8", features = ["derive"] }
-chrono = { version = "0.4.38", default-features = false }
+chrono = { version = "0.4.38", default-features = false, features = ["std"] }
 directories = "5.0.1"
 env_home = "0.1.0"
 env_logger = "0.10"
@@ -51,9 +52,4 @@ pattern_type_mismatch = { level = "allow", priority = 1 }
 print_stdout = { level = "allow", priority = 1 }
 std_instead_of_alloc = { level = "allow", priority = 1 }
 
-# TODO: Try to not depend on allowing these lints
-unwrap_used = { level = "allow", priority = 1 }
-get_unwrap = { level = "allow", priority = 1 }
-expect_used = { level = "allow", priority = 1 }
-panic = { level = "allow", priority = 1 }
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Options:
       --force-spirv-cli-rebuild
           Force `spirv-builder-cli` and `rustc_codegen_spirv` to be rebuilt
 
+      --auto-install-rust-toolchain
+          Assume "yes" to "Install Rust toolchain: [y/n]" prompt
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -133,6 +136,9 @@ Options:
 
       --force-spirv-cli-rebuild
           Force `spirv-builder-cli` and `rustc_codegen_spirv` to be rebuilt
+
+      --auto-install-rust-toolchain
+          Assume "yes" to "Install Rust toolchain: [y/n]" prompt
 
       --shader-target <SHADER_TARGET>
           Shader target
@@ -197,13 +203,44 @@ Options:
 
 Show some useful values
 
-Usage: cargo-gpu show [OPTIONS]
+Usage: cargo-gpu show <COMMAND>
+
+Commands:
+  cache-directory  Displays the location of the cache directory
+  spirv-source     The source location of spirv-std
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
-      --cache-directory
-          Displays the location of the cache directory
-
   -h, --help
           Print help
+
+
+    * Cache-directory
+
+    Displays the location of the cache directory
+
+    Usage: cargo-gpu show cache-directory
+
+    Options:
+      -h, --help
+              Print help
+
+
+    * Spirv-source
+
+    The source location of spirv-std
+
+    Usage: cargo-gpu show spirv-source [OPTIONS]
+
+    Options:
+          --shader-crate <SHADER_CRATE>
+              The location of the shader-crate to inspect to determine its spirv-std dependency
+
+              [default: ./]
+
+      -h, --help
+              Print help
+
+
 
 ````

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-panic-in-tests = true

--- a/crates/cargo-gpu/Cargo.toml
+++ b/crates/cargo-gpu/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 toml.workspace = true
 chrono.workspace = true
 http.workspace = true
+crossterm.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/crates/cargo-gpu/Cargo.toml
+++ b/crates/cargo-gpu/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["gpu", "compiler"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 spirv-builder-cli = { path = "../spirv-builder-cli", default-features = false }
 clap.workspace = true
 directories.workspace = true

--- a/crates/cargo-gpu/src/build.rs
+++ b/crates/cargo-gpu/src/build.rs
@@ -1,7 +1,5 @@
 //! `cargo gpu build`, analogous to `cargo build`
 
-use std::io::Write as _;
-
 use anyhow::Context as _;
 use clap::Parser;
 use spirv_builder_cli::{Linkage, ShaderModule};
@@ -64,6 +62,11 @@ impl Build {
         let arg = serde_json::to_string_pretty(&spirv_builder_args)?;
         log::info!("using spirv-builder-cli arg: {arg}");
 
+        crate::user_output!(
+            "Running `spirv-builder-cli` to compile shader at {}...\n",
+            self.install.shader_crate.display()
+        );
+
         // Call spirv-builder-cli to compile the shaders.
         let output = std::process::Command::new(spirv_builder_cli_path)
             .arg(arg)
@@ -112,7 +115,6 @@ impl Build {
         let manifest_path = self.output_dir.join("manifest.json");
         // Sort the contents so the output is deterministic
         linkage.sort();
-        // UNWRAP: safe because we know this always serializes
         let json = serde_json::to_string_pretty(&linkage)?;
         let mut file = std::fs::File::create(&manifest_path).with_context(|| {
             format!(

--- a/crates/cargo-gpu/src/install.rs
+++ b/crates/cargo-gpu/src/install.rs
@@ -1,6 +1,8 @@
 //! Install a dedicated per-shader crate that has the `rust-gpu` compiler in it.
 use std::io::Write as _;
 
+use anyhow::Context as _;
+
 use crate::{cache_dir, spirv_cli::SpirvCli, spirv_source::SpirvSource, target_spec_dir};
 
 /// These are the files needed to create the dedicated, per-shader `rust-gpu` builder create.
@@ -120,7 +122,7 @@ pub struct Install {
 
 impl Install {
     /// Returns a [`SpirvCLI`] instance, responsible for ensuring the right version of the `spirv-builder-cli` crate.
-    fn spirv_cli(&self, shader_crate_path: &std::path::PathBuf) -> SpirvCli {
+    fn spirv_cli(&self, shader_crate_path: &std::path::PathBuf) -> anyhow::Result<SpirvCli> {
         SpirvCli::new(
             shader_crate_path,
             self.spirv_builder_source.clone(),
@@ -130,20 +132,21 @@ impl Install {
     }
 
     /// Create the `spirv-builder-cli` crate.
-    fn write_source_files(&self) {
-        let spirv_cli = self.spirv_cli(&self.shader_crate);
-        let checkout = spirv_cli.cached_checkout_path();
-        std::fs::create_dir_all(checkout.join("src")).unwrap();
+    fn write_source_files(&self) -> anyhow::Result<()> {
+        let spirv_cli = self.spirv_cli(&self.shader_crate)?;
+        let checkout = spirv_cli.cached_checkout_path()?;
+        std::fs::create_dir_all(checkout.join("src"))?;
         for (filename, contents) in SPIRV_BUILDER_FILES {
             log::debug!("writing {filename}");
             let path = checkout.join(filename);
-            let mut file = std::fs::File::create(&path).unwrap();
+            let mut file = std::fs::File::create(&path)?;
             let mut replaced_contents = contents.replace("${CHANNEL}", &spirv_cli.channel);
             if filename == &"Cargo.toml" {
                 replaced_contents = Self::update_cargo_toml(&replaced_contents, &spirv_cli.source);
             }
-            file.write_all(replaced_contents.as_bytes()).unwrap();
+            file.write_all(replaced_contents.as_bytes())?;
         }
+        Ok(())
     }
 
     /// Update  the `Cargo.toml` file in the `spirv-builder-cli` crate so that it contains
@@ -176,33 +179,30 @@ impl Install {
     }
 
     /// Add the target spec files to the crate.
-    fn write_target_spec_files(&self) {
+    fn write_target_spec_files(&self) -> anyhow::Result<()> {
         for (filename, contents) in TARGET_SPECS {
-            let path = target_spec_dir().join(filename);
+            let path = target_spec_dir()?.join(filename);
             if !path.is_file() || self.force_spirv_cli_rebuild {
-                let mut file = std::fs::File::create(&path).unwrap();
-                file.write_all(contents.as_bytes()).unwrap();
+                let mut file = std::fs::File::create(&path)?;
+                file.write_all(contents.as_bytes())?;
             }
         }
+        Ok(())
     }
 
     /// Install the binary pair and return the paths, (dylib, cli).
-    pub fn run(&self) -> (std::path::PathBuf, std::path::PathBuf) {
+    pub fn run(&self) -> anyhow::Result<(std::path::PathBuf, std::path::PathBuf)> {
         // Ensure the cache dir exists
-        let cache_dir = cache_dir();
+        let cache_dir = cache_dir()?;
         log::info!("cache directory is '{}'", cache_dir.display());
-        std::fs::create_dir_all(&cache_dir).unwrap_or_else(|error| {
-            log::error!(
-                "could not create cache directory '{}': {error}",
-                cache_dir.display()
-            );
-            panic!("could not create cache dir");
-        });
+        std::fs::create_dir_all(&cache_dir).with_context(|| {
+            format!("could not create cache directory '{}'", cache_dir.display())
+        })?;
 
-        let spirv_version = self.spirv_cli(&self.shader_crate);
-        spirv_version.ensure_toolchain_and_components_exist();
+        let spirv_version = self.spirv_cli(&self.shader_crate)?;
+        spirv_version.ensure_toolchain_and_components_exist()?;
 
-        let checkout = spirv_version.cached_checkout_path();
+        let checkout = spirv_version.cached_checkout_path()?;
         let release = checkout.join("target").join("release");
 
         let dylib_filename = format!(
@@ -227,8 +227,8 @@ impl Install {
                 "writing spirv-builder-cli source files into '{}'",
                 checkout.display()
             );
-            self.write_source_files();
-            self.write_target_spec_files();
+            self.write_source_files()?;
+            self.write_target_spec_files()?;
 
             let mut command = std::process::Command::new("cargo");
             command
@@ -239,7 +239,7 @@ impl Install {
 
             command.args([
                 "--features",
-                &Self::get_required_spirv_builder_version(spirv_version.date),
+                &Self::get_required_spirv_builder_version(spirv_version.date)?,
             ]);
 
             log::debug!("building artifacts with `{:?}`", command);
@@ -247,16 +247,15 @@ impl Install {
             let output = command
                 .stdout(std::process::Stdio::inherit())
                 .stderr(std::process::Stdio::inherit())
-                .output()
-                .unwrap();
-            assert!(output.status.success(), "...build error!");
+                .output()?;
+            anyhow::ensure!(output.status.success(), "...build error!");
 
             if dylib_path.is_file() {
                 log::info!("successfully built {}", dylib_path.display());
-                std::fs::rename(&dylib_path, &dest_dylib_path).unwrap();
+                std::fs::rename(&dylib_path, &dest_dylib_path)?;
             } else {
                 log::error!("could not find {}", dylib_path.display());
-                panic!("spirv-builder-cli build failed");
+                anyhow::bail!("spirv-builder-cli build failed");
             }
 
             let cli_path = if cfg!(target_os = "windows") {
@@ -266,18 +265,18 @@ impl Install {
             };
             if cli_path.is_file() {
                 log::info!("successfully built {}", cli_path.display());
-                std::fs::rename(&cli_path, &dest_cli_path).unwrap();
+                std::fs::rename(&cli_path, &dest_cli_path)?;
             } else {
                 log::error!("could not find {}", cli_path.display());
                 log::debug!("contents of '{}':", release.display());
-                for maybe_entry in std::fs::read_dir(&release).unwrap() {
-                    let entry = maybe_entry.unwrap();
+                for maybe_entry in std::fs::read_dir(&release)? {
+                    let entry = maybe_entry?;
                     log::debug!("{}", entry.file_name().to_string_lossy());
                 }
-                panic!("spirv-builder-cli build failed");
+                anyhow::bail!("spirv-builder-cli build failed");
             }
         }
-        (dest_dylib_path, dest_cli_path)
+        Ok((dest_dylib_path, dest_cli_path))
     }
 
     /// The `spirv-builder` crate from the main `rust-gpu` repo hasn't always been setup to
@@ -287,15 +286,15 @@ impl Install {
     /// TODO:
     ///   * Warn the user that certain `cargo-gpu` features aren't available when building with
     ///     older versions of `spirv-builder`, eg setting the target spec.
-    fn get_required_spirv_builder_version(date: chrono::NaiveDate) -> String {
+    fn get_required_spirv_builder_version(date: chrono::NaiveDate) -> anyhow::Result<String> {
         let parse_date = chrono::NaiveDate::parse_from_str;
-        let pre_cli_date = parse_date("2024-04-24", "%Y-%m-%d").unwrap();
+        let pre_cli_date = parse_date("2024-04-24", "%Y-%m-%d")?;
 
-        if date < pre_cli_date {
+        Ok(if date < pre_cli_date {
             "spirv-builder-pre-cli"
         } else {
             "spirv-builder-0_10"
         }
-        .into()
+        .into())
     }
 }

--- a/crates/cargo-gpu/src/install.rs
+++ b/crates/cargo-gpu/src/install.rs
@@ -118,6 +118,10 @@ pub struct Install {
     /// Force `spirv-builder-cli` and `rustc_codegen_spirv` to be rebuilt.
     #[clap(long)]
     force_spirv_cli_rebuild: bool,
+
+    /// Assume "yes" to "Install Rust toolchain: [y/n]" prompt.
+    #[clap(long, action)]
+    auto_install_rust_toolchain: bool,
 }
 
 impl Install {
@@ -128,6 +132,7 @@ impl Install {
             self.spirv_builder_source.clone(),
             self.spirv_builder_version.clone(),
             self.rust_toolchain.clone(),
+            self.auto_install_rust_toolchain,
         )
     }
 
@@ -229,6 +234,11 @@ impl Install {
             );
             self.write_source_files()?;
             self.write_target_spec_files()?;
+
+            crate::user_output!(
+                "Compiling shader-specific `spirv-builder-cli` for {}\n",
+                self.shader_crate.display()
+            );
 
             let mut command = std::process::Command::new("cargo");
             command

--- a/crates/cargo-gpu/src/main.rs
+++ b/crates/cargo-gpu/src/main.rs
@@ -65,9 +65,51 @@ mod spirv_cli;
 mod spirv_source;
 mod toml;
 
-fn main() -> anyhow::Result<()> {
+/// Central function to write to the user.
+#[macro_export]
+macro_rules! user_output {
+    ($($args: tt)*) => {
+        #[allow(
+            clippy::allow_attributes,
+            clippy::useless_attribute,
+            unused_imports,
+            reason = "`std::io::Write` is only sometimes called??"
+        )]
+        use std::io::Write as _;
+
+        #[expect(
+            clippy::non_ascii_literal,
+            reason = "CRAB GOOD. CRAB IMPORTANT."
+        )]
+        {
+            print!("🦀 ");
+        }
+        print!($($args)*);
+        std::io::stdout().flush().unwrap();
+   }
+}
+
+fn main() {
+    #[cfg(debug_assertions)]
+    std::env::set_var("RUST_BACKTRACE", "1");
+
     env_logger::builder().init();
 
+    if let Err(error) = run() {
+        log::error!("{error:?}");
+
+        #[expect(
+            clippy::print_stderr,
+            reason = "Our central place for outputting error messages"
+        )]
+        {
+            eprintln!("Error: {error}");
+        }
+    };
+}
+
+/// Wrappable "main" to catch errors.
+fn run() -> anyhow::Result<()> {
     let args = std::env::args()
         .filter(|arg| {
             // Calling cargo-gpu as the cargo subcommand "cargo gpu" passes "gpu"
@@ -161,7 +203,7 @@ fn dump_full_usage_for_readme() -> anyhow::Result<()> {
     command.build();
 
     write_help(&mut buffer, &mut command, 0)?;
-    println!("{}", String::from_utf8(buffer)?);
+    user_output!("{}", String::from_utf8(buffer)?);
 
     Ok(())
 }

--- a/crates/cargo-gpu/src/main.rs
+++ b/crates/cargo-gpu/src/main.rs
@@ -50,6 +50,8 @@
 //! conduct other post-processing, like converting the `spv` files into `wgsl` files,
 //! for example.
 
+use anyhow::Context as _;
+
 use build::Build;
 use clap::Parser as _;
 use install::Install;
@@ -63,7 +65,7 @@ mod spirv_cli;
 mod spirv_source;
 mod toml;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     env_logger::builder().init();
 
     let args = std::env::args()
@@ -79,19 +81,21 @@ fn main() {
     match cli.command {
         Command::Install(install) => {
             log::debug!("installing with arguments: {install:#?}");
-            let (_, _) = install.run();
+            let (_, _) = install.run()?;
         }
         Command::Build(mut build) => {
             log::debug!("building with arguments: {build:#?}");
-            build.run();
+            build.run()?;
         }
         Command::Toml(toml) => {
             log::debug!("building by toml file with arguments: {toml:#?}");
-            toml.run();
+            toml.run()?;
         }
-        Command::Show(show) => show.run(),
-        Command::DumpUsage => dump_full_usage_for_readme(),
-    }
+        Command::Show(show) => show.run()?,
+        Command::DumpUsage => dump_full_usage_for_readme()?,
+    };
+
+    Ok(())
 }
 
 /// All of the available subcommands for `cargo gpu`
@@ -125,48 +129,51 @@ pub(crate) struct Cli {
     command: Command,
 }
 
-fn cache_dir() -> std::path::PathBuf {
+fn cache_dir() -> anyhow::Result<std::path::PathBuf> {
     let dir = directories::BaseDirs::new()
-        .unwrap_or_else(|| {
-            log::error!("could not find the user home directory");
-            panic!("cache_dir failed");
-        })
+        .with_context(|| "could not find the user home directory")?
         .cache_dir()
         .join("rust-gpu");
 
-    if cfg!(test) {
+    Ok(if cfg!(test) {
         let thread_id = std::thread::current().id();
         let id = format!("{thread_id:?}").replace('(', "-").replace(')', "");
         dir.join("tests").join(id)
     } else {
         dir
-    }
+    })
 }
 
 /// Location of the target spec metadata files
-fn target_spec_dir() -> std::path::PathBuf {
-    let dir = cache_dir().join("target-specs");
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
+fn target_spec_dir() -> anyhow::Result<std::path::PathBuf> {
+    let dir = cache_dir()?.join("target-specs");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
 }
 
 /// Convenience function for internal use. Dumps all the CLI usage instructions. Useful for
 /// updating the README.
-fn dump_full_usage_for_readme() {
+fn dump_full_usage_for_readme() -> anyhow::Result<()> {
     use clap::CommandFactory as _;
     let mut command = Cli::command();
 
     let mut buffer: Vec<u8> = Vec::default();
     command.build();
 
-    write_help(&mut buffer, &mut command, 0);
-    println!("{}", String::from_utf8(buffer).unwrap());
+    write_help(&mut buffer, &mut command, 0)?;
+    println!("{}", String::from_utf8(buffer)?);
+
+    Ok(())
 }
 
 /// Recursive function to print the usage instructions for each subcommand.
-fn write_help(buffer: &mut impl std::io::Write, cmd: &mut clap::Command, _depth: usize) {
+fn write_help(
+    buffer: &mut impl std::io::Write,
+    cmd: &mut clap::Command,
+    _depth: usize,
+) -> anyhow::Result<()> {
     if cmd.get_name() == "help" {
-        return;
+        return Ok(());
     }
 
     let mut command = cmd.get_name().to_owned();
@@ -175,16 +182,17 @@ fn write_help(buffer: &mut impl std::io::Write, cmd: &mut clap::Command, _depth:
         "\n* {}{}",
         command.remove(0).to_uppercase(),
         command
-    )
-    .unwrap();
-    writeln!(buffer).unwrap();
-    cmd.write_long_help(buffer).unwrap();
+    )?;
+    writeln!(buffer)?;
+    cmd.write_long_help(buffer)?;
 
     for sub in cmd.get_subcommands_mut() {
-        writeln!(buffer).unwrap();
+        writeln!(buffer)?;
         #[expect(clippy::used_underscore_binding, reason = "Used in recursion only")]
-        write_help(buffer, sub, _depth + 1);
+        write_help(buffer, sub, _depth + 1)?;
     }
+
+    Ok(())
 }
 
 /// Returns a string suitable to use as a directory.
@@ -210,7 +218,7 @@ mod test {
     }
 
     pub fn tests_teardown() {
-        let cache_dir = cache_dir();
+        let cache_dir = cache_dir().unwrap();
         if !cache_dir.exists() {
             return;
         }

--- a/crates/cargo-gpu/src/show.rs
+++ b/crates/cargo-gpu/src/show.rs
@@ -29,17 +29,19 @@ pub struct Show {
 
 impl Show {
     /// Entrypoint
-    pub fn run(self) {
+    pub fn run(self) -> anyhow::Result<()> {
         log::info!("{:?}: ", self.command);
         match self.command {
             Info::CacheDirectory => {
-                println!("{}", cache_dir().display());
+                println!("{}", cache_dir()?.display());
             }
             Info::SpirvSource(SpirvSourceDep { shader_crate }) => {
                 let rust_gpu_source =
-                    crate::spirv_source::SpirvSource::get_spirv_std_dep_definition(&shader_crate);
+                    crate::spirv_source::SpirvSource::get_spirv_std_dep_definition(&shader_crate)?;
                 println!("{rust_gpu_source}");
             }
         }
+
+        Ok(())
     }
 }

--- a/crates/cargo-gpu/src/show.rs
+++ b/crates/cargo-gpu/src/show.rs
@@ -33,12 +33,12 @@ impl Show {
         log::info!("{:?}: ", self.command);
         match self.command {
             Info::CacheDirectory => {
-                println!("{}", cache_dir()?.display());
+                crate::user_output!("{}\n", cache_dir()?.display());
             }
             Info::SpirvSource(SpirvSourceDep { shader_crate }) => {
                 let rust_gpu_source =
                     crate::spirv_source::SpirvSource::get_spirv_std_dep_definition(&shader_crate)?;
-                println!("{rust_gpu_source}");
+                crate::user_output!("{rust_gpu_source}\n");
             }
         }
 

--- a/crates/cargo-gpu/src/spirv_cli.rs
+++ b/crates/cargo-gpu/src/spirv_cli.rs
@@ -1,6 +1,8 @@
 //! Query the shader crate to find what version of `rust-gpu` it depends on.
 //! Then ensure that the relevant Rust toolchain and components are installed.
 
+use anyhow::Context as _;
+
 use crate::spirv_source::SpirvSource;
 
 /// Cargo dependency for `spirv-builder` and the rust toolchain channel.
@@ -40,9 +42,9 @@ impl SpirvCli {
         maybe_rust_gpu_source: Option<String>,
         maybe_rust_gpu_version: Option<String>,
         maybe_rust_gpu_channel: Option<String>,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let (default_rust_gpu_source, rust_gpu_date, default_rust_gpu_channel) =
-            SpirvSource::get_rust_gpu_deps_from_shader(shader_crate_path);
+            SpirvSource::get_rust_gpu_deps_from_shader(shader_crate_path)?;
 
         let mut maybe_spirv_source: Option<SpirvSource> = None;
         if let Some(rust_gpu_version) = maybe_rust_gpu_version {
@@ -56,27 +58,23 @@ impl SpirvCli {
             maybe_spirv_source = Some(source);
         }
 
-        Self {
+        Ok(Self {
             source: maybe_spirv_source.unwrap_or(default_rust_gpu_source),
             channel: maybe_rust_gpu_channel.unwrap_or(default_rust_gpu_channel),
             date: rust_gpu_date,
-        }
+        })
     }
 
     /// Create and/or return the cache directory
-    pub fn cached_checkout_path(&self) -> std::path::PathBuf {
-        let checkout_dir = crate::cache_dir()
+    pub fn cached_checkout_path(&self) -> anyhow::Result<std::path::PathBuf> {
+        let checkout_dir = crate::cache_dir()?
             .join("spirv-builder-cli")
             .join(crate::to_dirname(self.to_string().as_ref()));
-        std::fs::create_dir_all(&checkout_dir).unwrap_or_else(|error| {
-            log::error!(
-                "could not create checkout dir '{}': {error}",
-                checkout_dir.display()
-            );
-            panic!("could not create checkout dir");
-        });
+        std::fs::create_dir_all(&checkout_dir).with_context(|| {
+            format!("could not create checkout dir '{}'", checkout_dir.display())
+        })?;
 
-        checkout_dir
+        Ok(checkout_dir)
     }
 
     /// Use `rustup` to install the toolchain and components, if not already installed.
@@ -85,13 +83,12 @@ impl SpirvCli {
     ///
     /// * rustup toolchain add nightly-2024-04-24
     /// * rustup component add --toolchain nightly-2024-04-24 rust-src rustc-dev llvm-tools
-    pub fn ensure_toolchain_and_components_exist(&self) {
+    pub fn ensure_toolchain_and_components_exist(&self) -> anyhow::Result<()> {
         // Check for the required toolchain
         let output_toolchain_list = std::process::Command::new("rustup")
             .args(["toolchain", "list"])
-            .output()
-            .unwrap();
-        assert!(
+            .output()?;
+        anyhow::ensure!(
             output_toolchain_list.status.success(),
             "could not list installed toolchains"
         );
@@ -107,9 +104,8 @@ impl SpirvCli {
                 .arg(&self.channel)
                 .stdout(std::process::Stdio::inherit())
                 .stderr(std::process::Stdio::inherit())
-                .output()
-                .unwrap();
-            assert!(
+                .output()?;
+            anyhow::ensure!(
                 output_toolchain_add.status.success(),
                 "could not install required toolchain"
             );
@@ -119,9 +115,8 @@ impl SpirvCli {
         let output_component_list = std::process::Command::new("rustup")
             .args(["component", "list", "--toolchain"])
             .arg(&self.channel)
-            .output()
-            .unwrap();
-        assert!(
+            .output()?;
+        anyhow::ensure!(
             output_component_list.status.success(),
             "could not list installed components"
         );
@@ -144,13 +139,14 @@ impl SpirvCli {
                 .args(["rust-src", "rustc-dev", "llvm-tools"])
                 .stdout(std::process::Stdio::inherit())
                 .stderr(std::process::Stdio::inherit())
-                .output()
-                .unwrap();
-            assert!(
+                .output()?;
+            anyhow::ensure!(
                 output_component_add.status.success(),
                 "could not install required components"
             );
         }
+
+        Ok(())
     }
 }
 
@@ -161,8 +157,8 @@ mod test {
     #[test_log::test]
     fn cached_checkout_dir_sanity() {
         let shader_template_path = crate::test::shader_crate_template_path();
-        let spirv = SpirvCli::new(&shader_template_path, None, None, None);
-        let dir = spirv.cached_checkout_path();
+        let spirv = SpirvCli::new(&shader_template_path, None, None, None).unwrap();
+        let dir = spirv.cached_checkout_path().unwrap();
         let name = dir
             .file_name()
             .unwrap()

--- a/crates/cargo-gpu/src/spirv_source.rs
+++ b/crates/cargo-gpu/src/spirv_source.rs
@@ -320,6 +320,8 @@ impl SpirvSource {
             self.to_dirname()?.to_string_lossy().as_ref(),
         );
 
+        crate::user_output!("Cloning `rust-gpu` repo...");
+
         let output_clone = std::process::Command::new("git")
             .args([
                 "clone",

--- a/crates/cargo-gpu/src/spirv_source.rs
+++ b/crates/cargo-gpu/src/spirv_source.rs
@@ -4,6 +4,8 @@
 //! version. Then with that we `git checkout` the `rust-gpu` repo that corresponds to that version.
 //! From there we can look at the source code to get the required Rust toolchain.
 
+use anyhow::Context as _;
+
 /// The canonical `rust-gpu` URI
 const RUST_GPU_REPO: &str = "https://github.com/Rust-GPU/rust-gpu";
 
@@ -50,18 +52,18 @@ impl SpirvSource {
     /// Look into the shader crate to get the version of `rust-gpu` it's using.
     pub fn get_rust_gpu_deps_from_shader(
         shader_crate_path: &std::path::PathBuf,
-    ) -> (Self, chrono::NaiveDate, String) {
-        let rust_gpu_source = Self::get_spirv_std_dep_definition(shader_crate_path);
+    ) -> anyhow::Result<(Self, chrono::NaiveDate, String)> {
+        let rust_gpu_source = Self::get_spirv_std_dep_definition(shader_crate_path)?;
 
-        rust_gpu_source.ensure_repo_is_installed();
-        rust_gpu_source.checkout();
+        rust_gpu_source.ensure_repo_is_installed()?;
+        rust_gpu_source.checkout()?;
 
-        let date = rust_gpu_source.get_version_date();
-        let channel = Self::get_channel_from_toolchain_toml(&rust_gpu_source.to_dirname());
+        let date = rust_gpu_source.get_version_date()?;
+        let channel = Self::get_channel_from_toolchain_toml(&rust_gpu_source.to_dirname()?)?;
 
         log::debug!("Parsed version, date and toolchain channel from shader-defined `rust-gpu`: {rust_gpu_source:?}, {date}, {channel}");
 
-        (rust_gpu_source, date, channel)
+        Ok((rust_gpu_source, date, channel))
     }
 
     /// Convert the source to just its version.
@@ -84,42 +86,43 @@ impl SpirvSource {
     /// Convert the `rust-gpu` source into a string that can be used as a directory.
     /// It needs to be dynamically created because an end-user might want to swap out the source,
     /// maybe using their own fork for example.
-    fn to_dirname(&self) -> std::path::PathBuf {
+    fn to_dirname(&self) -> anyhow::Result<std::path::PathBuf> {
         let dir = crate::to_dirname(self.to_string().as_ref());
-        crate::cache_dir().join("rust-gpu-repo").join(dir)
+        Ok(crate::cache_dir()?.join("rust-gpu-repo").join(dir))
     }
 
     /// Checkout the `rust-gpu` repo to the requested version.
-    fn checkout(&self) {
+    fn checkout(&self) -> anyhow::Result<()> {
         log::debug!(
             "Checking out `rust-gpu` repo at {} to {}",
-            self.to_dirname().display(),
+            self.to_dirname()?.display(),
             self.to_version()
         );
         let output_checkout = std::process::Command::new("git")
-            .current_dir(self.to_dirname())
+            .current_dir(self.to_dirname()?)
             .args(["checkout", self.to_version().as_ref()])
-            .output()
-            .unwrap();
-        assert!(
+            .output()?;
+        anyhow::ensure!(
             output_checkout.status.success(),
             "couldn't checkout revision '{}' of `rust-gpu` at {}",
             self.to_version(),
-            self.to_dirname().to_string_lossy()
+            self.to_dirname()?.to_string_lossy()
         );
+
+        Ok(())
     }
 
     /// Get the date of the version of `rust-gpu` used by the shader. This allows us to know what
     /// features we can use in the `spirv-builder` crate.
-    fn get_version_date(&self) -> chrono::NaiveDate {
+    fn get_version_date(&self) -> anyhow::Result<chrono::NaiveDate> {
         let date_format = "%Y-%m-%d";
 
         log::debug!(
             "Getting `rust-gpu` version date from {}",
-            self.to_dirname().display(),
+            self.to_dirname()?.display(),
         );
         let output_date = std::process::Command::new("git")
-            .current_dir(self.to_dirname())
+            .current_dir(self.to_dirname()?)
             .args([
                 "show",
                 "--no-patch",
@@ -127,13 +130,12 @@ impl SpirvSource {
                 format!("--date=format:'{date_format}'").as_ref(),
                 self.to_version().as_ref(),
             ])
-            .output()
-            .unwrap();
-        assert!(
+            .output()?;
+        anyhow::ensure!(
             output_date.status.success(),
             "couldn't get `rust-gpu` version date at for {} at {}",
             self.to_version(),
-            self.to_dirname().to_string_lossy()
+            self.to_dirname()?.to_string_lossy()
         );
         let date_string = String::from_utf8_lossy(&output_date.stdout)
             .to_string()
@@ -145,47 +147,53 @@ impl SpirvSource {
             self.to_version()
         );
 
-        chrono::NaiveDate::parse_from_str(&date_string, date_format).unwrap()
+        Ok(chrono::NaiveDate::parse_from_str(
+            &date_string,
+            date_format,
+        )?)
     }
 
     /// Parse the `rust-toolchain.toml` in the working tree of the checked-out version of the `rust-gpu` repo.
-    fn get_channel_from_toolchain_toml(path: &std::path::PathBuf) -> String {
+    fn get_channel_from_toolchain_toml(path: &std::path::PathBuf) -> anyhow::Result<String> {
         log::debug!("Parsing `rust-toolchain.toml` at {path:?} for the used toolchain");
 
-        let contents = std::fs::read_to_string(path.join("rust-toolchain.toml")).unwrap();
-        let toml: toml::Table = toml::from_str(&contents).unwrap();
+        let contents = std::fs::read_to_string(path.join("rust-toolchain.toml"))?;
+        let toml: toml::Table = toml::from_str(&contents)?;
         let Some(toolchain) = toml.get("toolchain") else {
-            panic!("Couldn't find `[toolchain]` section in `rust-toolchain.toml` at {path:?}");
+            anyhow::bail!(
+                "Couldn't find `[toolchain]` section in `rust-toolchain.toml` at {path:?}"
+            );
         };
         let Some(channel) = toolchain.get("channel") else {
-            panic!("Couldn't find `channel` field in `rust-toolchain.toml` at {path:?}");
+            anyhow::bail!("Couldn't find `channel` field in `rust-toolchain.toml` at {path:?}");
         };
 
-        channel.to_string().replace('"', "")
+        Ok(channel.to_string().replace('"', ""))
     }
 
     /// Get the shader crate's `spirv_std = ...` definition in its `Cargo.toml`
-    pub fn get_spirv_std_dep_definition(shader_crate_path: &std::path::PathBuf) -> Self {
-        let cwd = std::env::current_dir().expect("no cwd");
+    pub fn get_spirv_std_dep_definition(
+        shader_crate_path: &std::path::PathBuf,
+    ) -> anyhow::Result<Self> {
+        let cwd = std::env::current_dir().context("no cwd")?;
         let exec_path = if shader_crate_path.is_absolute() {
             shader_crate_path.clone()
         } else {
             cwd.join(shader_crate_path)
         }
         .canonicalize()
-        .expect("could not get absolute path to shader crate");
+        .context("could not get absolute path to shader crate")?;
         if !exec_path.is_dir() {
             log::error!("{exec_path:?} is not a directory, aborting");
-            panic!("{exec_path:?} is not a directory");
+            anyhow::bail!("{exec_path:?} is not a directory");
         }
 
         log::debug!("Running `cargo tree` on {}", exec_path.display());
         let output_cargo_tree = std::process::Command::new("cargo")
             .current_dir(&exec_path)
             .args(["tree", "--workspace", "--prefix", "none"])
-            .output()
-            .unwrap();
-        assert!(
+            .output()?;
+        anyhow::ensure!(
             output_cargo_tree.status.success(),
             "could not query shader's `Cargo.toml` for `spirv-std` dependency"
         );
@@ -197,7 +205,7 @@ impl SpirvSource {
         log::trace!("  found {maybe_spirv_std_def:?}");
 
         let Some(spirv_std_def) = maybe_spirv_std_def else {
-            panic!("`spirv-std` not found in shader's `Cargo.toml` at {exec_path:?}:\n{cargo_tree_string}");
+            anyhow::bail!("`spirv-std` not found in shader's `Cargo.toml` at {exec_path:?}:\n{cargo_tree_string}");
         };
 
         Self::parse_spirv_std_source_and_version(spirv_std_def)
@@ -207,17 +215,20 @@ impl SpirvSource {
     ///   `spirv-std v0.9.0 (https://github.com/Rust-GPU/rust-gpu?rev=54f6978c#54f6978c) (*)`
     /// Which would return:
     ///   `SpirvSource::Git("https://github.com/Rust-GPU/rust-gpu", "54f6978c")`
-    fn parse_spirv_std_source_and_version(spirv_std_def: &str) -> Self {
+    fn parse_spirv_std_source_and_version(spirv_std_def: &str) -> anyhow::Result<Self> {
         log::trace!("parsing spirv-std source and version from def: '{spirv_std_def}'");
         let parts: Vec<String> = spirv_std_def.split_whitespace().map(String::from).collect();
         let version = parts
             .get(1)
-            .expect("Couldn't find `spirv_std` version in shader crate")
+            .context("Couldn't find `spirv_std` version in shader crate")?
             .to_owned();
         let mut source = Self::CratesIO(version.clone());
 
         if parts.len() > 2 {
-            let mut source_string = parts.get(2).unwrap().to_owned();
+            let mut source_string = parts
+                .get(2)
+                .context("Couldn't get Uri from dependency string")?
+                .to_owned();
             source_string = source_string.replace(['(', ')'], "");
 
             // Unfortunately Uri ignores the fragment/hash portion of the Uri.
@@ -226,7 +237,7 @@ impl SpirvSource {
             // <https://github.com/hyperium/http/issues/127>
             //
             // So here we'll parse the fragment out of the source string by hand
-            let uri = source_string.parse::<http::Uri>().unwrap();
+            let uri = source_string.parse::<http::Uri>()?;
             let maybe_hash = if source_string.contains('#') {
                 let splits = source_string.split('#');
                 splits.last().map(std::borrow::ToOwned::to_owned)
@@ -234,7 +245,7 @@ impl SpirvSource {
                 None
             };
             if uri.scheme().is_some() {
-                source = Self::parse_git_source(version, &uri, maybe_hash);
+                source = Self::parse_git_source(version, &uri, maybe_hash)?;
             } else {
                 source = Self::Path((source_string, version));
             }
@@ -242,69 +253,90 @@ impl SpirvSource {
 
         log::debug!("Parsed `rust-gpu` source and version: {source:?}");
 
-        source
+        Ok(source)
     }
 
     /// Parse a Git source like: `https://github.com/Rust-GPU/rust-gpu?rev=54f6978c#54f6978c`
-    fn parse_git_source(version: String, uri: &http::Uri, fragment: Option<String>) -> Self {
+    fn parse_git_source(
+        version: String,
+        uri: &http::Uri,
+        fragment: Option<String>,
+    ) -> anyhow::Result<Self> {
         log::trace!(
             "parsing git source from version: '{version}' and uri: '{uri}' and fragment: {}",
             fragment.as_deref().unwrap_or("?")
         );
         let repo = format!(
             "{}://{}{}",
-            uri.scheme().unwrap(),
-            uri.host().unwrap(),
+            uri.scheme().context("Couldn't parse scheme from Uri")?,
+            uri.host().context("Couldn't parse host from Uri")?,
             uri.path()
         );
 
-        let rev = uri.query().map_or_else(
-            || fragment.unwrap_or(version),
-            |query| {
-                let marker = "rev=";
-                let sanity_check = query.contains(marker) && query.split('=').count() == 2;
-                assert!(sanity_check, "revision not found in Git URI: {query}");
-                query.replace(marker, "")
-            },
-        );
+        let rev = Self::parse_git_revision(uri.query(), fragment, version);
 
-        Self::Git { url: repo, rev }
+        Ok(Self::Git { url: repo, rev })
+    }
+
+    /// Decide the Git revision to use.
+    fn parse_git_revision(
+        maybe_query: Option<&str>,
+        maybe_fragment: Option<String>,
+        version: String,
+    ) -> String {
+        let marker = "rev=";
+        let maybe_sane_query = maybe_query.and_then(|query| {
+            // TODO: This might seem a little crude, but it saves adding a whole query parsing dependency.
+            let sanity_check = query.contains(marker) && query.split('=').count() == 2;
+            sanity_check.then_some(query)
+        });
+
+        if let Some(query) = maybe_sane_query {
+            return query.replace(marker, "");
+        }
+
+        if let Some(fragment) = maybe_fragment {
+            return fragment;
+        }
+
+        version
     }
 
     /// `git clone` the `rust-gpu` repo. We use it to get the required Rust toolchain to compile
     /// the shader.
-    fn ensure_repo_is_installed(&self) {
-        if self.to_dirname().exists() {
+    fn ensure_repo_is_installed(&self) -> anyhow::Result<()> {
+        if self.to_dirname()?.exists() {
             log::debug!(
                 "Not cloning `rust-gpu` repo ({}) as it already exists at {}",
                 self.to_repo(),
-                self.to_dirname().to_string_lossy().as_ref(),
+                self.to_dirname()?.to_string_lossy().as_ref(),
             );
-            return;
+            return Ok(());
         }
 
         log::debug!(
             "Cloning `rust-gpu` repo {} to {}",
             self.to_repo(),
-            self.to_dirname().to_string_lossy().as_ref(),
+            self.to_dirname()?.to_string_lossy().as_ref(),
         );
 
         let output_clone = std::process::Command::new("git")
             .args([
                 "clone",
                 self.to_repo().as_ref(),
-                self.to_dirname().to_string_lossy().as_ref(),
+                self.to_dirname()?.to_string_lossy().as_ref(),
             ])
-            .output()
-            .unwrap();
+            .output()?;
 
-        assert!(
+        anyhow::ensure!(
             output_clone.status.success(),
             "couldn't clone `rust-gpu` {} to {}\n{}",
             self.to_repo(),
-            self.to_dirname().to_string_lossy(),
+            self.to_dirname()?.to_string_lossy(),
             String::from_utf8_lossy(&output_clone.stderr)
         );
+
+        Ok(())
     }
 }
 
@@ -315,7 +347,7 @@ mod test {
     #[test_log::test]
     fn parsing_spirv_std_dep_for_shader_template() {
         let shader_template_path = crate::test::shader_crate_template_path();
-        let source = SpirvSource::get_spirv_std_dep_definition(&shader_template_path);
+        let source = SpirvSource::get_spirv_std_dep_definition(&shader_template_path).unwrap();
         assert_eq!(
             source,
             SpirvSource::Git {
@@ -329,7 +361,7 @@ mod test {
     fn parsing_spirv_std_dep_for_git_source() {
         let definition =
             "spirv-std v9.9.9 (https://github.com/Rust-GPU/rust-gpu?rev=82a0f69#82a0f69) (*)";
-        let source = SpirvSource::parse_spirv_std_source_and_version(definition);
+        let source = SpirvSource::parse_spirv_std_source_and_version(definition).unwrap();
         assert_eq!(
             source,
             SpirvSource::Git {
@@ -342,7 +374,7 @@ mod test {
     #[test_log::test]
     fn parsing_spirv_std_dep_for_git_source_hash() {
         let definition = "spirv-std v9.9.9 (https://github.com/Rust-GPU/rust-gpu#82a0f69) (*)";
-        let source = SpirvSource::parse_spirv_std_source_and_version(definition);
+        let source = SpirvSource::parse_spirv_std_source_and_version(definition).unwrap();
         assert_eq!(
             source,
             SpirvSource::Git {

--- a/crates/spirv-builder-cli/Cargo.toml
+++ b/crates/spirv-builder-cli/Cargo.toml
@@ -41,3 +41,8 @@ package = "spirv-builder"
 optional = true
 git = "https://github.com/Rust-GPU/rust-gpu" # ${AUTO-REPLACE-SOURCE}
 rev = "60dcb82" # ${AUTO-REPLACE-VERSION}
+
+[lints.rust]
+# This crate is most often run by end users compiling their shaders so it's not so relevant
+# for them to see warnings.
+warnings = "allow"

--- a/crates/spirv-builder-cli/src/main.rs
+++ b/crates/spirv-builder-cli/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
     let mut shaders = vec![];
     match module {
         ModuleResult::MultiModule(modules) => {
-            anyhow::ensure!(!modules.is_empty(), "No shader modules to compile");
+            assert!(!modules.is_empty(), "No shader modules to compile");
             for (entry, filepath) in modules.into_iter() {
                 log::debug!("compiled {entry} {}", filepath.display());
                 shaders.push(ShaderModule::new(entry, filepath));

--- a/crates/spirv-builder-cli/src/main.rs
+++ b/crates/spirv-builder-cli/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
     let mut shaders = vec![];
     match module {
         ModuleResult::MultiModule(modules) => {
-            assert!(!modules.is_empty(), "No shader modules to compile");
+            anyhow::ensure!(!modules.is_empty(), "No shader modules to compile");
             for (entry, filepath) in modules.into_iter() {
                 log::debug!("compiled {entry} {}", filepath.display());
                 shaders.push(ShaderModule::new(entry, filepath));

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 [group: 'ci']
 build-shader-template:
   cargo install --path crates/cargo-gpu
-  cargo gpu install --shader-crate crates/shader-crate-template
+  cargo gpu install --shader-crate crates/shader-crate-template --auto-install-rust-toolchain
   cargo gpu build --shader-crate crates/shader-crate-template --output-dir test-shaders
   ls -lah test-shaders
   cat test-shaders/manifest.json


### PR DESCRIPTION
There's now prompts for when Rust toolchain assets need to be installed. Surprisingly responding to a prompt with a single keypress requires a whole crate, namely `crossterm`.

Also all the code is now "panic-less", so no `unwrap()`, `panic()`, etc. Everything goes through `?` thanks to the `anyhow` crate.

Fixes #14