### PR TITLE
Add `--watch` arg for auto re-compiling on shader changes

### DIFF
--- a/crates/cargo-gpu/src/main.rs
+++ b/crates/cargo-gpu/src/main.rs
@@ -141,7 +141,16 @@ fn run() -> anyhow::Result<()> {
             let mut command =
                 config::Config::clap_command_with_cargo_config(&shader_crate_path, env_args)?;
             log::debug!("building with final merged arguments: {command:#?}");
-            command.run()?;
+
+            if command.build_args.watch {
+                //  When watching, do one normal run to setup the `manifest.json` file.
+                command.build_args.watch = false;
+                command.run()?;
+                command.build_args.watch = true;
+                command.run()?;
+            } else {
+                command.run()?;
+            }
         }
         Command::Show(show) => show.run()?,
         Command::DumpUsage => dump_full_usage_for_readme()?,

--- a/crates/spirv-builder-cli/Cargo.toml
+++ b/crates/spirv-builder-cli/Cargo.toml
@@ -40,12 +40,14 @@ optional = true
 
 [dependencies.spirv-builder-pre-cli]
 package = "spirv-builder"
+features = [ "watch" ]
 optional = true
 git = "https://github.com/Rust-GPU/rust-gpu" # ${AUTO-REPLACE-SOURCE}
 rev = "4c633aec" # ${AUTO-REPLACE-VERSION}
 
 [dependencies.spirv-builder-0_10]
 package = "spirv-builder"
+features = [ "watch" ]
 optional = true
 git = "https://github.com/Rust-GPU/rust-gpu" # ${AUTO-REPLACE-SOURCE}
 rev = "60dcb82" # ${AUTO-REPLACE-VERSION}

--- a/crates/spirv-builder-cli/src/args.rs
+++ b/crates/spirv-builder-cli/src/args.rs
@@ -6,7 +6,7 @@ use spirv_0_3 as spirv;
 
 use std::str::FromStr as _;
 
-#[derive(clap::Parser, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(clap::Parser, Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct AllArgs {
     #[clap(flatten)]
     pub build: BuildArgs,
@@ -26,11 +26,15 @@ pub enum SpirvMetadata {
     Full,
 }
 
-#[derive(clap::Parser, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(clap::Parser, Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct BuildArgs {
     /// Path to the output directory for the compiled shaders.
     #[clap(long, short, default_value = "./")]
     pub output_dir: std::path::PathBuf,
+
+    /// Watch the shader crate directory and automatically recompile on changes.
+    #[clap(long, short, action)]
+    pub watch: bool,
 
     /// Set shader crate's cargo default-features.
     #[clap(long)]
@@ -133,7 +137,7 @@ impl BuildArgs {
     }
 }
 
-#[derive(clap::Parser, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(clap::Parser, Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct InstallArgs {
     #[clap(long, hide(true), default_value = "INTERNALLY_SET")]
     pub dylib_path: std::path::PathBuf,

--- a/crates/spirv-builder-cli/src/main.rs
+++ b/crates/spirv-builder-cli/src/main.rs
@@ -42,6 +42,32 @@ fn set_codegen_spirv_location(dylib_path: std::path::PathBuf) {
     std::env::set_var(env_var, path);
 }
 
+fn handle_compile_result(result: &CompileResult, args: &args::AllArgs) {
+    log::debug!("found entry points: {:#?}", result.entry_points);
+
+    let dir = &args.build.output_dir;
+    let mut shaders = vec![];
+    match &result.module {
+        ModuleResult::MultiModule(modules) => {
+            assert!(!modules.is_empty(), "No shader modules to compile");
+            for (entry, filepath) in modules.clone().into_iter() {
+                log::debug!("compiled {entry} {}", filepath.display());
+                shaders.push(ShaderModule::new(entry, filepath));
+            }
+        }
+        ModuleResult::SingleModule(filepath) => {
+            for entry in result.entry_points.clone() {
+                shaders.push(ShaderModule::new(entry, filepath.clone()));
+            }
+        }
+    }
+
+    use std::io::Write;
+    let mut file = std::fs::File::create(dir.join("spirv-manifest.json")).unwrap();
+    file.write_all(&serde_json::to_vec(&shaders).unwrap())
+        .unwrap();
+}
+
 pub fn main() {
     env_logger::builder().init();
 
@@ -54,6 +80,7 @@ pub fn main() {
     );
     log::debug!("with args: {args:#?}");
     let args: args::AllArgs = serde_json::from_str(&args[1]).unwrap();
+    let args_for_result = args.clone();
 
     let spirv_metadata = match args.build.spirv_metadata {
         args::SpirvMetadata::None => spirv_builder::SpirvMetadata::None,
@@ -61,77 +88,59 @@ pub fn main() {
         args::SpirvMetadata::Full => spirv_builder::SpirvMetadata::Full,
     };
 
-    let CompileResult {
-        entry_points,
-        module,
-    } = {
-        let mut builder = SpirvBuilder::new(args.install.shader_crate, &args.build.target)
-            .deny_warnings(args.build.deny_warnings)
-            .release(!args.build.debug)
-            .multimodule(args.build.multimodule)
-            .spirv_metadata(spirv_metadata)
-            .relax_struct_store(args.build.relax_struct_store)
-            .relax_logical_pointer(args.build.relax_logical_pointer)
-            .relax_block_layout(args.build.relax_block_layout)
-            .uniform_buffer_standard_layout(args.build.uniform_buffer_standard_layout)
-            .scalar_block_layout(args.build.scalar_block_layout)
-            .skip_block_layout(args.build.skip_block_layout)
-            .preserve_bindings(args.build.preserve_bindings)
-            .print_metadata(spirv_builder::MetadataPrintout::None);
+    let mut builder = SpirvBuilder::new(args.install.shader_crate, &args.build.target)
+        .deny_warnings(args.build.deny_warnings)
+        .release(!args.build.debug)
+        .multimodule(args.build.multimodule)
+        .spirv_metadata(spirv_metadata)
+        .relax_struct_store(args.build.relax_struct_store)
+        .relax_logical_pointer(args.build.relax_logical_pointer)
+        .relax_block_layout(args.build.relax_block_layout)
+        .uniform_buffer_standard_layout(args.build.uniform_buffer_standard_layout)
+        .scalar_block_layout(args.build.scalar_block_layout)
+        .skip_block_layout(args.build.skip_block_layout)
+        .preserve_bindings(args.build.preserve_bindings)
+        .print_metadata(spirv_builder::MetadataPrintout::None);
 
-        for capability in &args.build.capability {
-            builder = builder.capability(*capability);
+    for capability in &args.build.capability {
+        builder = builder.capability(*capability);
+    }
+
+    for extension in &args.build.extension {
+        builder = builder.extension(extension);
+    }
+
+    #[cfg(feature = "spirv-builder-pre-cli")]
+    {
+        set_codegen_spirv_location(args.install.dylib_path);
+    }
+
+    #[cfg(feature = "spirv-builder-0_10")]
+    {
+        builder = builder
+            .rustc_codegen_spirv_location(args.install.dylib_path)
+            .target_spec(args.build.shader_target);
+
+        if args.build.no_default_features {
+            log::info!("setting cargo --no-default-features");
+            builder = builder.shader_crate_default_features(false);
         }
-
-        for extension in &args.build.extension {
-            builder = builder.extension(extension);
-        }
-
-        #[cfg(feature = "spirv-builder-pre-cli")]
-        {
-            set_codegen_spirv_location(args.install.dylib_path);
-        }
-
-        #[cfg(feature = "spirv-builder-0_10")]
-        {
-            builder = builder
-                .rustc_codegen_spirv_location(args.install.dylib_path)
-                .target_spec(args.build.shader_target);
-
-            if args.build.no_default_features {
-                log::info!("setting cargo --no-default-features");
-                builder = builder.shader_crate_default_features(false);
-            }
-            if !args.build.features.is_empty() {
-                log::info!("setting --features {:?}", args.build.features);
-                builder = builder.shader_crate_features(args.build.features);
-            }
-        }
-
-        log::debug!("Calling `rust-gpu`'s `spirv-builder` library");
-        builder.build().unwrap()
-    };
-    log::debug!("found entry points: {entry_points:#?}");
-
-    let dir = args.build.output_dir;
-    let mut shaders = vec![];
-    match module {
-        ModuleResult::MultiModule(modules) => {
-            assert!(!modules.is_empty(), "No shader modules to compile");
-            for (entry, filepath) in modules.into_iter() {
-                log::debug!("compiled {entry} {}", filepath.display());
-                shaders.push(ShaderModule::new(entry, filepath));
-            }
-        }
-        ModuleResult::SingleModule(filepath) => {
-            for entry in entry_points {
-                shaders.push(ShaderModule::new(entry, filepath.clone()));
-            }
+        if !args.build.features.is_empty() {
+            log::info!("setting --features {:?}", args.build.features);
+            builder = builder.shader_crate_features(args.build.features);
         }
     }
 
-    use std::io::Write;
-    let mut file = std::fs::File::create(dir.join("spirv-manifest.json")).unwrap();
-    file.write_all(&serde_json::to_vec(&shaders).unwrap())
-        .unwrap();
+    log::debug!("Calling `rust-gpu`'s `spirv-builder` library");
+
+    if args.build.watch {
+        println!("🦀 Watching and recompiling shader on changes...");
+        builder.watch(move |compile_result| {
+            handle_compile_result(&compile_result, &args_for_result);
+        });
+        std::thread::park();
+    } else {
+        let result = builder.build().unwrap();
+        handle_compile_result(&result, &args_for_result);
+    }
 }


### PR DESCRIPTION
I know we'd mentioned this before, and decided it wasn't high priority. Because https://github.com/Canop/bacon exists. But I just thought I'd make a PR so we can see how simple the code change is.

I think there's advantages to having native watching. Like not having to download and learn another tool.