### PR TITLE
Include Cargo.lock in when copying spirv-builder-cli

### DIFF
--- a/crates/cargo-gpu/src/install.rs
+++ b/crates/cargo-gpu/src/install.rs
@@ -13,6 +13,10 @@ const SPIRV_BUILDER_FILES: &[(&str, &str)] = &[
         include_str!("../../spirv-builder-cli/Cargo.toml"),
     ),
     (
+        "Cargo.lock",
+        include_str!("../../spirv-builder-cli/Cargo.lock"),
+    ),
+    (
         "src/main.rs",
         include_str!("../../spirv-builder-cli/src/main.rs"),
     ),


### PR DESCRIPTION
I see that CI is failing across the board, both on `main` and PRs. [It looks like it's because we're not getting reproducible builds in `spirv-builder-cli`](https://github.com/Rust-GPU/cargo-gpu/actions/runs/13148527758/job/36691597389#step:7:391). When it's copied during `cargo gpu install`, it's not copying `spirv-builder-cli`'s `Cargo.lock`. So this PR adds it.

Hopefully that doesn't increase the binary size too much?