### PR TITLE
add manifest-file configuration option to BuildArgs

### DIFF
--- a/crates/cargo-gpu/src/build.rs
+++ b/crates/cargo-gpu/src/build.rs
@@ -121,7 +121,10 @@ impl Build {
             .collect::<anyhow::Result<Vec<Linkage>>>()?;
 
         // Write the shader manifest json file
-        let manifest_path = self.build_args.output_dir.join("manifest.json");
+        let manifest_path = self
+            .build_args
+            .output_dir
+            .join(&self.build_args.manifest_file);
         // Sort the contents so the output is deterministic
         linkage.sort();
         let json = serde_json::to_string_pretty(&linkage)?;

--- a/crates/cargo-gpu/src/config.rs
+++ b/crates/cargo-gpu/src/config.rs
@@ -241,4 +241,21 @@ mod test {
             ]
         );
     }
+
+    #[test_log::test]
+    fn rename_manifest_parse() {
+        let shader_crate_path = crate::test::shader_crate_test_path();
+
+        let args = Config::clap_command_with_cargo_config(
+            &shader_crate_path,
+            vec![
+                "gpu".to_owned(),
+                "build".to_owned(),
+                "--manifest-file".to_owned(),
+                "mymanifest".to_owned(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(args.build_args.manifest_file, "mymanifest".to_owned());
+    }
 }

--- a/crates/shader-crate-template/Cargo.toml
+++ b/crates/shader-crate-template/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-gpu-shader-crate-template"
 version = "0.1.0"
 edition = "2021"
- 
+
 [lib]
 crate-type = ["rlib", "cdylib"]
 
@@ -25,7 +25,7 @@ glam = { version = "0.29", features = ["std"] }
 output-dir = "./"
 # Set shader crate's cargo default-features
 no_default_features = false
-# Set shader crate's cargo features.  
+# Set shader crate's cargo features.
 features = []
 # The compile target.
 # TODO: `cargo gpu show targets` for all available options.
@@ -51,7 +51,7 @@ spirv-metadata = "None"
 relax-struct-store = false
 # Allow allocating an object of a pointer type and returning a pointer value from a function
 # in logical addressing mode.
-relax-logical-pointer =  false
+relax-logical-pointer = false
 # Enable VK_KHR_relaxed_block_layout when checking standard uniform, storage buffer, and push
 # constant layouts.
 # This is the default when targeting Vulkan 1.1 or later.
@@ -68,6 +68,9 @@ scalar-block-layout = false
 skip-block-layout = false
 # Preserve unused descriptor bindings. Useful for reflection.
 preserve-bindings = false
+# Renames the manifest.json file to the given string. Useful if you collect all your SPIR-V fragments
+# in one place.
+manifest-file = "manifest.json"
 
 [package.metadata.rust-gpu.install]
 # Source of `spirv-builder` dependency

--- a/crates/spirv-builder-cli/src/args.rs
+++ b/crates/spirv-builder-cli/src/args.rs
@@ -115,6 +115,10 @@ pub struct BuildArgs {
     /// Preserve unused descriptor bindings. Useful for reflection.
     #[arg(long, default_value = "false")]
     pub preserve_bindings: bool,
+
+    ///Renames the manifest.json file to the given name
+    #[clap(long, short, default_value = "manifest.json")]
+    pub manifest_file: String,
 }
 
 impl BuildArgs {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -122,6 +122,7 @@ fn main() {
             .unwrap();
 
             cmd(["ls", "-lah", dir.path().to_str().unwrap()]).unwrap();
+            //NOTE: manifest.json is the default value here, which should be valid
             cmd(["cat", dir.path().join("manifest.json").to_str().unwrap()]).unwrap();
         }
     }


### PR DESCRIPTION
This adds an option to the `BuildArgs` to rename mainfest files. The default case stays `manifest.json`.

Currently, the name is hardcoded to manifest.json, which becomes a problem when you collect all your SPIR-V fragments in one place. This way you can still use manifest files to parse your entrypoints.