### PR TITLE
Capture initial Enter key release

### DIFF
--- a/crates/cargo-gpu/src/spirv_cli.rs
+++ b/crates/cargo-gpu/src/spirv_cli.rs
@@ -209,8 +209,19 @@ impl SpirvCli {
         }
         log::debug!("asking for consent to install the required toolchain");
         crossterm::terminal::enable_raw_mode().context("enabling raw mode")?;
-        crate::user_output!("{prompt} [y/n]: ");
-        let input = crossterm::event::read().context("reading crossterm event")?;
+        crate::user_output!("{prompt} [y/n]: \n");
+        let mut input = crossterm::event::read().context("reading crossterm event")?;
+
+        if let crossterm::event::Event::Key(crossterm::event::KeyEvent {
+            code: crossterm::event::KeyCode::Enter,
+            kind: crossterm::event::KeyEventKind::Release,
+            ..
+        }) = input
+        {
+            // In Powershell, programs will potentially observe the Enter key release after they started
+            // (see crossterm#124). If that happens, re-read the input.
+            input = crossterm::event::read().context("re-reading crossterm event")?;
+        }
         crossterm::terminal::disable_raw_mode().context("disabling raw mode")?;
 
         if let crossterm::event::Event::Key(crossterm::event::KeyEvent {


### PR DESCRIPTION
Part of some minor issues I ran into in #58:

When installing with Powershell, `cargo gpu build` will be started with an Enter keydown, but has an opportunity to observe the corresponding Enter keyup event too (see https://github.com/crossterm-rs/crossterm/issues/124). When this happens, it's impossible run `cargo gpu build` without `--auto-install-rust-toolchain` because I'm unable to press "y".

I don't think it's ever expected for the first interaction in a terminal to be a keyup event, so maybe we can just re-read the input if that happens?