### PR TITLE
Update README.md with workspace install path, new template crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Command line tool for building Rust shaders using rust-gpu.
 To install the tool ensure you have `rustup`. Then run:
 
 ```
-cargo install --git https://github.com/rust-gpu/cargo-gpu
+cargo install --git https://github.com/rust-gpu/cargo-gpu cargo-gpu
 ```
 
 After that you can use `cargo gpu` to compile your shader crates with:
@@ -25,13 +25,13 @@ Use `cargo gpu help` to see other options :)
 
 ### Next Steps
 
-You can try this out using the example repo at <https://github.com/rust-GPU/shader-crate-template>.
-Keep in mind <https://github.com/rust-GPU/shader-crate-template> is _not_ yet a cargo generate template,
+You can try this out using the example repo at <https://github.com/rust-GPU/cargo-gpu/crates/shader-crate-template>.
+Keep in mind <https://github.com/rust-GPU/cargo-gpu/crates/shader-crate-template> is _not_ yet a cargo generate template,
 it's just a normal repo.
 
 ```
-git clone https://github.com/rust-GPU/shader-crate-template
-cd shader-crate-template
+git clone https://github.com/rust-GPU/cargo-gpu
+cd cargo-gpu/crates/shader-crate-template
 cargo gpu build
 ```
 


### PR DESCRIPTION
Part of some minor issues I hit while getting started in #58.

Minor updates, but helpful to make sure things work off the bat. Given the workspace `shader-crate-template` has more thorough examples for package metadata, I assume that's what people should look at, but let me know if that's mistaken.