### PR TITLE
Preserve existing dylib paths before calling spirv-builder

### DIFF
--- a/crates/spirv-builder-cli/src/main.rs
+++ b/crates/spirv-builder-cli/src/main.rs
@@ -37,7 +37,14 @@ const fn dylib_path_envvar() -> &'static str {
 
 fn set_codegen_spirv_location(dylib_path: std::path::PathBuf) {
     let env_var = dylib_path_envvar();
-    let path = dylib_path.parent().unwrap().display().to_string();
+    let existing_paths_str = std::env::var(env_var).unwrap();
+    let mut dylib_paths = std::env::split_paths(&existing_paths_str).collect::<Vec<_>>();
+
+    let dylib_path = dylib_path.parent().unwrap().to_path_buf();
+    dylib_paths.insert(0, dylib_path);
+
+    let path = std::env::join_paths(dylib_paths).unwrap().into_string().unwrap();
+
     log::debug!("Setting OS-dependent DLL ENV path ({env_var}) to: {path}");
     std::env::set_var(env_var, path);
 }


### PR DESCRIPTION
In #20, `spirv-builder-cli` sets up the environment to load `rustc_codegen_spirv`, but does so without preserving existing paths. Because `spirv-builder-cli` sets the `PATH` variable on Windows, [`spirv-builder`](https://github.com/Rust-GPU/rust-gpu/blob/05042d1713012862be103e85bfd2c15dfeccda7b/crates/spirv-builder/src/lib.rs#L797) is then unable to find the `cargo` command, causing the issues seen in #50.

Instead, prepend the necessary paths so `spirv-builder` can find `cargo`.