### PR TITLE
Update `rust-gpu` to the latest `main`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ checksum = "6c89eaf493b3dfc730cda42a77014aad65e03213992c7afe0dff60a9f7d3dd94"
 [[package]]
 name = "rustc_codegen_spirv-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=e6d017d5504c4441a84edcc27f4eca61de6fc8cf#e6d017d5504c4441a84edcc27f4eca61de6fc8cf"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=f58374079a72ee1f73bf2a9bdaed435b5e44e20e#f58374079a72ee1f73bf2a9bdaed435b5e44e20e"
 dependencies = [
  "rspirv",
  "serde",
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "spirv-builder"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=e6d017d5504c4441a84edcc27f4eca61de6fc8cf#e6d017d5504c4441a84edcc27f4eca61de6fc8cf"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=f58374079a72ee1f73bf2a9bdaed435b5e44e20e#f58374079a72ee1f73bf2a9bdaed435b5e44e20e"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-spirv-builder = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "e6d017d5504c4441a84edcc27f4eca61de6fc8cf", default-features = false }
+spirv-builder = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "f58374079a72ee1f73bf2a9bdaed435b5e44e20e", default-features = false }
 anyhow = "1.0.94"
 clap = { version = "4.5.37", features = ["derive"] }
 crossterm = "0.28.1"


### PR DESCRIPTION
Simply updates to the latest `main`, otherwise patching is quite cumbersome with `git` dependencies.

I'm specifically interested in pulling https://github.com/Rust-GPU/rust-gpu/pull/302.