### PR TITLE
fix: ensure -p package is resolved to shader crate before build and install commands are reconstructed

### DIFF
--- a/crates/cargo-gpu/src/build.rs
+++ b/crates/cargo-gpu/src/build.rs
@@ -61,9 +61,7 @@ impl Build {
         let installed_backend = self.install.run()?;
         let mut metadata = crate::metadata::MetadataCache::default();
 
-        if let Some(package) = self.install.package.as_ref() {
-            self.install.shader_crate = metadata.resolve_package_to_shader_crate(package)?;
-        }
+        self.install.shader_crate = self.install.get_resolved_shader_crate(&mut metadata)?;
 
         let _lockfile_mismatch_handler = LockfileMismatchHandler::new(
             &self.install.shader_crate,

--- a/crates/cargo-gpu/src/lib.rs
+++ b/crates/cargo-gpu/src/lib.rs
@@ -128,9 +128,12 @@ impl Command {
     ) -> anyhow::Result<()> {
         match &self {
             Self::Install(install) => {
-                let shader_crate_path = &install.shader_crate;
+                // NOTE: Here `install` is only used for its `shader_crate` field, the rest is
+                // not used, as config::Config::clap_command_with_cargo_config reconstructs
+                // the command from the environment.
+                let shader_crate_path = install.get_resolved_shader_crate(metadata_cache)?;
                 let command = config::Config::clap_command_with_cargo_config(
-                    shader_crate_path,
+                    &shader_crate_path,
                     env_args,
                     metadata_cache,
                 )?;
@@ -141,9 +144,12 @@ impl Command {
                 command.install.run()?;
             }
             Self::Build(build) => {
-                let shader_crate_path = &build.install.shader_crate;
+                // NOTE: Here `build` is only used for its `shader_crate` field, the rest is
+                // not used, as config::Config::clap_command_with_cargo_config reconstructs
+                // the command from the environment.
+                let shader_crate_path = build.install.get_resolved_shader_crate(metadata_cache)?;
                 let mut command = config::Config::clap_command_with_cargo_config(
-                    shader_crate_path,
+                    &shader_crate_path,
                     env_args,
                     metadata_cache,
                 )?;


### PR DESCRIPTION
These changes ensure that the correct shader crate is used to search for metadata. Previously the install and build commands' fields were being clobbered before the resolution could happen. I've pulled up the shader crate resolution to happen at the top of the call tree, before merging arguments.  