### PR TITLE
`cargo gpu clippy` and `check`

### DIFF
--- a/crates/cargo-gpu/src/config.rs
+++ b/crates/cargo-gpu/src/config.rs
@@ -31,7 +31,7 @@ impl Config {
     ) -> anyhow::Result<crate::build::Build> {
         let mut config = metadata.as_json(shader_crate_path)?;
 
-        env_args.retain(|arg| !(arg == "build" || arg == "install"));
+        env_args.retain(|arg| !(arg == "build" || arg == "install" || arg == "clippy"));
         let cli_args_json = Self::cli_args_to_json(env_args)?;
         Self::json_merge(&mut config, cli_args_json, None)?;
 

--- a/crates/cargo-gpu/src/config.rs
+++ b/crates/cargo-gpu/src/config.rs
@@ -31,7 +31,9 @@ impl Config {
     ) -> anyhow::Result<crate::build::Build> {
         let mut config = metadata.as_json(shader_crate_path)?;
 
-        env_args.retain(|arg| !(arg == "build" || arg == "install" || arg == "clippy"));
+        env_args.retain(|arg| {
+            !(arg == "build" || arg == "install" || arg == "check" || arg == "clippy")
+        });
         let cli_args_json = Self::cli_args_to_json(env_args)?;
         Self::json_merge(&mut config, cli_args_json, None)?;
 

--- a/crates/shader-crate-template/Cargo.toml
+++ b/crates/shader-crate-template/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["rlib", "cdylib"]
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_arch, values("spirv"))'] }
+
 # Dependencies for CPU and GPU code
 [dependencies]
 # TODO: use a simple crate version once v0.10.0 is released


### PR DESCRIPTION
* `cargo gpu clippy` allows you to run clippy with a spirv target, which can check code hidden by `#[cfg(target_arch = "spirv")]`, that `cargo clippy --all-targets` does not. 
* Also adds `cargo gpu check`, not sure how useful it'll be.
* **WON'T** add `cargo gpu fmt` since `cargo fmt` is fully target independent. We could use the fmt of the rust-gpu rust toolchain, but at worst that'll get you different formatting from whatever stable toolchain you're using. 

* enabled by
  * custom cargo commands in https://github.com/Rust-GPU/rust-gpu/pull/477
  * proper no artifact handing in https://github.com/Rust-GPU/rust-gpu/pull/496