### PR TITLE
 copy less strict lint config from rust-gpu 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,28 +43,82 @@ cargo-util-schemas = "0.8.2"
 semver = "1.0.26"
 dunce = "1.0.5"
 
+
+
 [workspace.lints.rust]
 missing_docs = "warn"
+# copied from rust-gpu
+future_incompatible = "warn"
+nonstandard_style = "warn"
+rust_2018_idioms = "warn"
 
 [workspace.lints.clippy]
-all = { level = "warn", priority = 0 }
-pedantic = { level = "warn", priority = 0 }
-nursery = { level = "warn", priority = 0 }
-cargo = { level = "warn", priority = 0 }
-restriction = { level = "warn", priority = 0 }
-blanket_clippy_restriction_lints = { level = "allow", priority = 1 }
-
-arithmetic_side_effects = { level = "allow", priority = 1 }
-absolute_paths = { level = "allow", priority = 1 }
-cargo_common_metadata = { level = "allow", priority = 1 }
-implicit_return = { level = "allow", priority = 1 }
-single_call_fn = { level = "allow", priority = 1 }
-question_mark_used = { level = "allow", priority = 1 }
-multiple_crate_versions = { level = "allow", priority = 1 }
-pub_with_shorthand = { level = "allow", priority = 1 }
-partial_pub_fields = { level = "allow", priority = 1 }
-pattern_type_mismatch = { level = "allow", priority = 1 }
-std_instead_of_alloc = { level = "allow", priority = 1 }
-arbitrary_source_item_ordering = { level = "allow", priority = 1 }
-missing_inline_in_public_items = { level = "allow", priority = 1 }
-doc_paragraphs_missing_punctuation = { level = "allow", priority = 1 }
+print_stdout = "deny"
+print_stderr = "deny"
+exit = "deny"
+# copied from rust-gpu
+all = { level = "warn", priority = -1 }
+await_holding_lock = "warn"
+char_lit_as_u8 = "warn"
+checked_conversions = "warn"
+dbg_macro = "warn"
+debug_assert_with_mut_call = "warn"
+doc_markdown = "warn"
+empty_enums = "warn"
+enum_glob_use = "warn"
+#exit = "warn"
+expl_impl_clone_on_copy = "warn"
+explicit_deref_methods = "warn"
+explicit_into_iter_loop = "warn"
+fallible_impl_from = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+float_cmp_const = "warn"
+fn_params_excessive_bools = "warn"
+from_iter_instead_of_collect = "warn"
+if_let_mutex = "warn"
+implicit_clone = "warn"
+imprecise_flops = "warn"
+inefficient_to_string = "warn"
+invalid_upcast_comparisons = "warn"
+large_digit_groups = "warn"
+large_stack_arrays = "warn"
+large_types_passed_by_value = "warn"
+let_unit_value = "warn"
+linkedlist = "warn"
+lossy_float_literal = "warn"
+macro_use_imports = "warn"
+manual_ok_or = "warn"
+map_err_ignore = "warn"
+map_flatten = "warn"
+map_unwrap_or = "warn"
+match_same_arms = "warn"
+match_wild_err_arm = "warn"
+match_wildcard_for_single_variants = "warn"
+mem_forget = "warn"
+missing_enforced_import_renames = "warn"
+mut_mut = "warn"
+mutex_integer = "warn"
+needless_borrow = "warn"
+needless_continue = "warn"
+needless_for_each = "warn"
+option_option = "warn"
+path_buf_push_overwrite = "warn"
+ptr_as_ptr = "warn"
+rc_mutex = "warn"
+ref_option_ref = "warn"
+rest_pat_in_fully_bound_structs = "warn"
+same_functions_in_if_condition = "warn"
+semicolon_if_nothing_returned = "warn"
+single_match_else = "warn"
+string_add_assign = "warn"
+string_add = "warn"
+string_lit_as_bytes = "warn"
+todo = "warn"
+trait_duplication_in_bounds = "warn"
+unimplemented = "warn"
+unnested_or_patterns = "warn"
+unused_self = "warn"
+useless_transmute = "warn"
+verbose_file_reads = "warn"
+zero_sized_map_values = "warn"

--- a/crates/cargo-gpu/src/main.rs
+++ b/crates/cargo-gpu/src/main.rs
@@ -17,10 +17,6 @@ fn main() {
         )]
         {
             eprintln!("Error: {error}");
-
-            // `clippy::exit` seems to be a false positive in `main()`.
-            // See: https://github.com/rust-lang/rust-clippy/issues/13518
-            #[expect(clippy::restriction, reason = "Our central place for safely exiting")]
             std::process::exit(1);
         };
     }


### PR DESCRIPTION
I feel like the lint settings in this repo make me waste a lot of time cleaning up needless stuff, I'd like them lowered to what rust-gpu currently has.