### PR TITLE
ci: drop 0.8.0

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -52,8 +52,10 @@ jobs:
           #    """
           # It's probably easily fixable. But also `0.7.0` was released in April 2023, so there's
           # unlikely many users of it?
-          - rust-gpu-version: 0.8.0
-            glam-version: 0.24.2
+
+          # 0.8.0 started failing as well due to `zmij v1.0.20` requiring rustc 1.71 or newer
+#          - rust-gpu-version: 0.8.0
+#            glam-version: 0.24.2
           - rust-gpu-version: 0.9.0
             glam-version: 0.24.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,4 @@ pattern_type_mismatch = { level = "allow", priority = 1 }
 std_instead_of_alloc = { level = "allow", priority = 1 }
 arbitrary_source_item_ordering = { level = "allow", priority = 1 }
 missing_inline_in_public_items = { level = "allow", priority = 1 }
+doc_paragraphs_missing_punctuation = { level = "allow", priority = 1 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -36,6 +36,7 @@ enum Cli {
     },
 }
 
+/// run some cmd
 fn cmd(args: impl IntoIterator<Item = impl AsRef<str>>) -> anyhow::Result<()> {
     let mut args = args.into_iter();
     let mut cmd = std::process::Command::new(args.next().context("no args")?.as_ref());


### PR DESCRIPTION
* drop 0.8.0 testing
* fix clippy (commit cherry-picked from https://github.com/Rust-GPU/cargo-gpu/pull/137)