### PR TITLE
Toolchain update for rustc 1.92.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustc_codegen_spirv-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=e7e447a9395a77caec5cbddea556af86bc68c573#e7e447a9395a77caec5cbddea556af86bc68c573"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
 dependencies = [
  "rspirv",
  "semver",
@@ -1193,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "spirv-builder"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=e7e447a9395a77caec5cbddea556af86bc68c573#e7e447a9395a77caec5cbddea556af86bc68c573"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["gpu", "compiler", "rust-gpu"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-spirv-builder = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "e7e447a9395a77caec5cbddea556af86bc68c573", default-features = false }
+spirv-builder = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "6a67e7b5954f37989ad540a555b5d6969073592e", default-features = false }
 cargo-gpu-install = { path = "./crates/cargo-gpu-install" }
 anyhow = "1.0.98"
 clap = { version = "4.5.41", features = ["derive"] }

--- a/crates/cargo-gpu-install/src/spirv_source.rs
+++ b/crates/cargo-gpu-install/src/spirv_source.rs
@@ -276,7 +276,7 @@ mod test {
             source,
             SpirvSource::Git {
                 url: "https://github.com/Rust-GPU/rust-gpu".to_owned(),
-                rev: "2aa4d4f8a8ba73103501562cfca17b8163e5a887".to_owned()
+                rev: "6a67e7b5954f37989ad540a555b5d6969073592e".to_owned()
             }
         );
     }
@@ -299,13 +299,13 @@ mod test {
             .to_str()
             .map(std::string::ToString::to_string)
             .unwrap();
-        assert_eq!("https___github_com_Rust-GPU_rust-gpu+2aa4d4f8", &name);
+        assert_eq!("https___github_com_Rust-GPU_rust-gpu+6a67e7b5", &name);
     }
 
     #[test_log::test]
     fn parse_git_with_rev() {
         let source = parse_git(
-            "git+https://github.com/Rust-GPU/rust-gpu?rev=86fc48032c4cd4afb74f1d81ae859711d20386a1#86fc4803",
+            "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#86fc4803",
         );
         assert_eq!(
             source,

--- a/crates/shader-crate-template/Cargo.lock
+++ b/crates/shader-crate-template/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "spirv-std"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=2aa4d4f8a8ba73103501562cfca17b8163e5a887#2aa4d4f8a8ba73103501562cfca17b8163e5a887"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
 dependencies = [
  "bitflags",
  "glam",
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-macros"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=2aa4d4f8a8ba73103501562cfca17b8163e5a887#2aa4d4f8a8ba73103501562cfca17b8163e5a887"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -92,7 +92,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=2aa4d4f8a8ba73103501562cfca17b8163e5a887#2aa4d4f8a8ba73103501562cfca17b8163e5a887"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
 
 [[package]]
 name = "syn"

--- a/crates/shader-crate-template/Cargo.toml
+++ b/crates/shader-crate-template/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_arch, values("spir
 # Dependencies for CPU and GPU code
 [dependencies]
 # TODO: use a simple crate version once v0.10.0 is released
-spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "2aa4d4f8a8ba73103501562cfca17b8163e5a887" }
+spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "6a67e7b5954f37989ad540a555b5d6969073592e" }
 glam = { version = "0.30.8", default-features = false }
 
 [package.metadata.rust-gpu.build]


### PR DESCRIPTION
# Requires rev change once https://github.com/Rust-GPU/rust-gpu/pull/543 is merged

* see https://github.com/Rust-GPU/rust-gpu/pull/543 
* updates spirv-builder to that PR
* required since target spec jsons changed again
* updates "shader crate template" to that PR as well to catch errors