### PR TITLE
update rust-gpu to PR #545

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel PR actions on new commits
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # For setup-rust, see https://github.com/moonrepo/setup-rust/issues/22
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -98,6 +98,14 @@ jobs:
             glam-version: =0.30.7
           # after, glam >0.30.8
           - rust-gpu-version: e767f24f2565baf1a71bbaf84d453d181cab2417
+
+          # rustc 1.94.0 destabilised json target specs, requiring `-Ztarget-spec-json`
+          # see https://github.com/Rust-GPU/rust-gpu/pull/545
+          # see https://github.com/rust-lang/rust/pull/150151
+          # before
+          - rust-gpu-version: 30896871ba00e668029ccb724f1438202b284708
+          # after
+          - rust-gpu-version: 877bd8697a15f3e6d09446a5e1807e6237ca1dac
     runs-on: ubuntu-latest
     env:
       RUST_LOG: debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustc_codegen_spirv-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
 dependencies = [
  "rspirv",
  "semver",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "spirv-builder"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "clap",
  "crossterm",
  "directories",
+ "expect-test",
  "log",
  "serde",
  "spirv-builder",
@@ -350,6 +351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "document-features"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +418,16 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1764,7 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "regex-lite",
  "tempfile",
  "toml 0.9.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ cargo_metadata = "0.21.0"
 cargo-util-schemas = "0.8.2"
 semver = "1.0.26"
 dunce = "1.0.5"
+expect-test = "1.5.1"
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["gpu", "compiler", "rust-gpu"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-spirv-builder = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "6a67e7b5954f37989ad540a555b5d6969073592e", default-features = false }
+spirv-builder = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "877bd8697a15f3e6d09446a5e1807e6237ca1dac", default-features = false }
 cargo-gpu-install = { path = "./crates/cargo-gpu-install" }
 anyhow = "1.0.98"
 clap = { version = "4.5.41", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ cargo-util-schemas = "0.8.2"
 semver = "1.0.26"
 dunce = "1.0.5"
 expect-test = "1.5.1"
+regex-lite = "0.1.9"
 
 
 

--- a/crates/cargo-gpu-install/Cargo.toml
+++ b/crates/cargo-gpu-install/Cargo.toml
@@ -29,6 +29,7 @@ tempfile = { workspace = true, optional = true }
 test-log.workspace = true
 cargo_metadata = { workspace = true, features = ["builder"] }
 cargo-util-schemas = "0.8.2"
+expect-test = "1.5.1"
 
 [lints]
 workspace = true

--- a/crates/cargo-gpu-install/src/spirv_source.rs
+++ b/crates/cargo-gpu-install/src/spirv_source.rs
@@ -267,24 +267,18 @@ mod test {
     use crate::test::TestEnv;
     use cargo_metadata::{PackageBuilder, PackageId, Source};
     use cargo_util_schemas::manifest::PackageName;
+    use expect_test::expect;
 
     #[test_log::test]
     fn parsing_spirv_std_dep_for_shader_template() {
         let shader_template_path = crate::test::shader_crate_template_path();
         let source = SpirvSource::get_rust_gpu_deps_from_shader(&shader_template_path).unwrap();
-        assert_eq!(
-            source,
-            SpirvSource::Git {
-                url: "https://github.com/Rust-GPU/rust-gpu".to_owned(),
-                rev: "6a67e7b5954f37989ad540a555b5d6969073592e".to_owned()
-            }
-        );
-    }
-
-    #[test_log::test]
-    fn path_sanity() {
-        let path = std::path::PathBuf::from("./");
-        assert!(path.is_relative());
+        expect![[r#"
+            Git {
+                url: "https://github.com/Rust-GPU/rust-gpu",
+                rev: "6a67e7b5954f37989ad540a555b5d6969073592e",
+            }"#]]
+        .assert_eq(&format!("{source:#?}"));
     }
 
     #[test_log::test]
@@ -299,7 +293,13 @@ mod test {
             .to_str()
             .map(std::string::ToString::to_string)
             .unwrap();
-        assert_eq!("https___github_com_Rust-GPU_rust-gpu+6a67e7b5", &name);
+        expect!["https___github_com_Rust-GPU_rust-gpu+6a67e7b5"].assert_eq(&name);
+    }
+
+    #[test_log::test]
+    fn path_sanity() {
+        let path = std::path::PathBuf::from("./");
+        assert!(path.is_relative());
     }
 
     #[test_log::test]

--- a/crates/cargo-gpu-install/src/spirv_source.rs
+++ b/crates/cargo-gpu-install/src/spirv_source.rs
@@ -276,7 +276,7 @@ mod test {
         expect![[r#"
             Git {
                 url: "https://github.com/Rust-GPU/rust-gpu",
-                rev: "6a67e7b5954f37989ad540a555b5d6969073592e",
+                rev: "877bd8697a15f3e6d09446a5e1807e6237ca1dac",
             }"#]]
         .assert_eq(&format!("{source:#?}"));
     }
@@ -293,7 +293,7 @@ mod test {
             .to_str()
             .map(std::string::ToString::to_string)
             .unwrap();
-        expect!["https___github_com_Rust-GPU_rust-gpu+6a67e7b5"].assert_eq(&name);
+        expect!["https___github_com_Rust-GPU_rust-gpu+877bd869"].assert_eq(&name);
     }
 
     #[test_log::test]

--- a/crates/shader-crate-template/Cargo.lock
+++ b/crates/shader-crate-template/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "spirv-std"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
 dependencies = [
  "bitflags",
  "glam",
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-macros"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -92,7 +92,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=6a67e7b5954f37989ad540a555b5d6969073592e#6a67e7b5954f37989ad540a555b5d6969073592e"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
 
 [[package]]
 name = "syn"

--- a/crates/shader-crate-template/Cargo.toml
+++ b/crates/shader-crate-template/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_arch, values("spir
 # Dependencies for CPU and GPU code
 [dependencies]
 # TODO: use a simple crate version once v0.10.0 is released
-spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "6a67e7b5954f37989ad540a555b5d6969073592e" }
+spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "877bd8697a15f3e6d09446a5e1807e6237ca1dac" }
 glam = { version = "0.30.8", default-features = false }
 
 [package.metadata.rust-gpu.build]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,6 +10,7 @@ env_logger.workspace = true
 log.workspace = true
 tempfile.workspace = true
 toml.workspace = true
+regex-lite.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,6 +6,7 @@
     reason = "This is just a workflow tool"
 )]
 
+use std::ffi::OsStr;
 use anyhow::Context as _;
 use clap::Parser as _;
 
@@ -34,23 +35,17 @@ enum Cli {
         #[clap(long)]
         git: Option<String>,
     },
+    UpdateExpect,
 }
 
 /// run some cmd
-fn cmd(args: impl IntoIterator<Item = impl AsRef<str>>) -> anyhow::Result<()> {
+fn cmd(args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> anyhow::Result<()> {
     let mut args = args.into_iter();
-    let mut cmd = std::process::Command::new(args.next().context("no args")?.as_ref());
-    for arg in args {
-        cmd.arg(arg.as_ref());
-    }
-
-    let output = cmd
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .output()
+    let status = std::process::Command::new(args.next().context("no args")?.as_ref())
+        .args(args)
+        .status()
         .context("cmd failed")?;
-    anyhow::ensure!(output.status.success());
-
+    anyhow::ensure!(status.success());
     Ok(())
 }
 
@@ -306,6 +301,13 @@ fn main() -> anyhow::Result<()> {
                 package,
                 &DependencyVersion::parse(version.clone(), git.clone())?,
             )?;
+        }
+        Cli::UpdateExpect => {
+            let status = std::process::Command::new("cargo")
+                .args(["nextest", "run"])
+                .env("UPDATE_EXPECT", "1")
+                .status()?;
+            anyhow::ensure!(status.success());
         }
     }
     Ok(())

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,9 +6,11 @@
     reason = "This is just a workflow tool"
 )]
 
-use std::ffi::OsStr;
 use anyhow::Context as _;
 use clap::Parser as _;
+use std::borrow::Cow;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 
 /// Path to the shader crate
 const SHADER_CRATE_PATH: &str = "crates/shader-crate-template";
@@ -36,6 +38,9 @@ enum Cli {
         git: Option<String>,
     },
     UpdateExpect,
+    RustGpuRev {
+        rev: String,
+    },
 }
 
 /// run some cmd
@@ -254,61 +259,101 @@ impl DependencyVersion {
 
 /// Run the xtask.
 fn main() -> anyhow::Result<()> {
-    env_logger::builder().init();
-    let cli = Cli::parse();
-    match &cli {
-        Cli::TestBuild {
-            rust_gpu_version,
-            glam_version,
-        } => {
-            log::info!("installing cargo gpu");
-            cmd(["cargo", "install", "--path", "crates/cargo-gpu"])?;
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+    Cli::parse().run()
+}
 
-            log::info!("setup project");
-            let mut overwriter = ShaderCrateTemplateCargoTomlWriter::default();
-            let dir = tempfile::TempDir::with_prefix("test-shader-output")?;
-            overwriter.replace_output_dir(dir.path())?;
-            if let Some(rust_gpu_version) = rust_gpu_version.as_ref() {
-                overwriter.set_spirv_std_version(rust_gpu_version)?;
+impl Cli {
+    fn run(&self) -> anyhow::Result<()> {
+        match &self {
+            Cli::TestBuild {
+                rust_gpu_version,
+                glam_version,
+            } => {
+                log::info!("installing cargo gpu");
+                cmd(["cargo", "install", "--path", "crates/cargo-gpu"])?;
+
+                log::info!("setup project");
+                let mut overwriter = ShaderCrateTemplateCargoTomlWriter::default();
+                let dir = tempfile::TempDir::with_prefix("test-shader-output")?;
+                overwriter.replace_output_dir(dir.path())?;
+                if let Some(rust_gpu_version) = rust_gpu_version.as_ref() {
+                    overwriter.set_spirv_std_version(rust_gpu_version)?;
+                }
+                if let Some(glam_version) = glam_version.as_ref() {
+                    overwriter.set_dependency_glam(glam_version)?;
+                }
+
+                log::info!("building with auto-install");
+                cmd([
+                    "cargo",
+                    "gpu",
+                    "build",
+                    "--shader-crate",
+                    SHADER_CRATE_PATH,
+                    "--auto-install-rust-toolchain",
+                    "--rebuild-codegen",
+                    "--force-overwrite-lockfiles-v4-to-v3",
+                ])?;
+
+                cmd(["ls", "-lah", dir.path().to_str().unwrap()])?;
+                //NOTE: manifest.json is the default value here, which should be valid
+                cmd(["cat", dir.path().join("manifest.json").to_str().unwrap()])?;
             }
-            if let Some(glam_version) = glam_version.as_ref() {
-                overwriter.set_dependency_glam(glam_version)?;
-            }
-
-            log::info!("building with auto-install");
-            cmd([
-                "cargo",
-                "gpu",
-                "build",
-                "--shader-crate",
-                SHADER_CRATE_PATH,
-                "--auto-install-rust-toolchain",
-                "--rebuild-codegen",
-                "--force-overwrite-lockfiles-v4-to-v3",
-            ])?;
-
-            cmd(["ls", "-lah", dir.path().to_str().unwrap()])?;
-            //NOTE: manifest.json is the default value here, which should be valid
-            cmd(["cat", dir.path().join("manifest.json").to_str().unwrap()])?;
-        }
-        Cli::SetDependency {
-            package,
-            version,
-            git,
-        } => {
-            let mut overwriter = ShaderCrateTemplateCargoTomlWriter::new(true);
-            overwriter.set_dependency(
+            Cli::SetDependency {
                 package,
-                &DependencyVersion::parse(version.clone(), git.clone())?,
-            )?;
+                version,
+                git,
+            } => {
+                let mut overwriter = ShaderCrateTemplateCargoTomlWriter::new(true);
+                overwriter.set_dependency(
+                    package,
+                    &DependencyVersion::parse(version.clone(), git.clone())?,
+                )?;
+            }
+            Cli::UpdateExpect => {
+                let status = std::process::Command::new("cargo")
+                    .args(["nextest", "run"])
+                    .env("UPDATE_EXPECT", "1")
+                    .status()?;
+                anyhow::ensure!(status.success());
+            }
+            Cli::RustGpuRev { rev } => {
+                let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../.."));
+                let rev_regex = regex_lite::Regex::new(r#"rev\s*=\s*"[0-9a-f]*""#)?;
+                let rev_replace = format!("rev = \"{rev}\"");
+                let replace_rev = |file: &Path, dep: &str| -> anyhow::Result<()> {
+                    log::info!("patching file `{}` dep `{dep}`", file.display());
+                    let content = std::fs::read_to_string(file)?;
+                    let content = content
+                        // unlike `.lines()`, includes the `\n` or `\r\n` at the end of the line
+                        .split_inclusive("\n")
+                        .map(|line| {
+                            if line.starts_with(dep) {
+                                let replace = rev_regex.replace(line, &rev_replace);
+                                assert!(
+                                    matches!(replace, Cow::Owned(..)),
+                                    "rev not found in line:\n{line}"
+                                );
+                                replace
+                            } else {
+                                Cow::Borrowed(line)
+                            }
+                        })
+                        .collect::<String>();
+                    std::fs::write(file, content.as_bytes())?;
+                    Ok(())
+                };
+                replace_rev(&root.join("Cargo.toml"), "spirv-builder")?;
+                replace_rev(
+                    &root.join("crates/shader-crate-template/Cargo.toml"),
+                    "spirv-std",
+                )?;
+                Cli::UpdateExpect.run()?;
+            }
         }
-        Cli::UpdateExpect => {
-            let status = std::process::Command::new("cargo")
-                .args(["nextest", "run"])
-                .env("UPDATE_EXPECT", "1")
-                .status()?;
-            anyhow::ensure!(status.success());
-        }
+        Ok(())
     }
-    Ok(())
 }


### PR DESCRIPTION
* update rust-gpu to https://github.com/Rust-GPU/rust-gpu/pull/545
  * spirv-builder changes in that PR may cause old toolchains to fail? yep, needed adjusting
* add `cargo xtask rust-gpu-rev <rev>` to automate rust-gpu dep upgrading
* use [`expect-test`](https://crates.io/crates/expect-test) crate (from rust-analyzer project) to update expected strings in tests